### PR TITLE
Refine async bridge with reusable background loop

### DIFF
--- a/active-development/packages/sdk-python/pyproject.toml
+++ b/active-development/packages/sdk-python/pyproject.toml
@@ -139,7 +139,7 @@ python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 markers = [
-    "slow: marks tests as slow (deselect with '-m "not slow"')",
+    "slow: marks tests as slow (deselect with -m \"not slow\")",
     "integration: marks tests as integration tests",
     "unit: marks tests as unit tests",
 ]
@@ -163,8 +163,8 @@ exclude_lines = [
     "raise NotImplementedError",
     "if 0:",
     "if __name__ == .__main__.:",
-    "class .*\bProtocol\):",
-    "@(abc\.)?abstractmethod",
+    'class .*\\bProtocol\\):',
+    '@(abc\\.)?abstractmethod',
 ]
 
 [tool.ruff]

--- a/active-development/packages/sdk-python/src/parserator/integrations/__init__.py
+++ b/active-development/packages/sdk-python/src/parserator/integrations/__init__.py
@@ -3,12 +3,12 @@ Parserator Framework Integrations
 Provides seamless integration with popular AI agent frameworks
 """
 
-from .langchain import ParseatorOutputParser
-from .crewai import ParseatorTool  
-from .autogpt import ParseatorPlugin
+from .langchain import ParseratorOutputParser
+from .crewai import ParseratorTool
+from .autogpt import ParseratorPlugin
 
 __all__ = [
-    'ParseatorOutputParser',
-    'ParseatorTool',
-    'ParseatorPlugin'
+    "ParseratorOutputParser",
+    "ParseratorTool",
+    "ParseratorPlugin",
 ]

--- a/active-development/packages/sdk-python/src/parserator/integrations/_async_utils.py
+++ b/active-development/packages/sdk-python/src/parserator/integrations/_async_utils.py
@@ -1,0 +1,140 @@
+"""Utilities for bridging async Parserator client calls from sync integrations."""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import contextvars
+import threading
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+_T = TypeVar("_T")
+
+
+async def _resolve(awaitable: Awaitable[_T]) -> _T:
+    """Await an awaitable value and return the resolved result."""
+
+    return await awaitable
+
+
+class _BackgroundLoop:
+    """Manage a dedicated event loop running in a background thread."""
+
+    def __init__(self) -> None:
+        self._loop_ready = threading.Event()
+        self._lock = threading.Lock()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+
+    def _run_loop(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        self._loop_ready.set()
+
+        try:
+            loop.run_forever()
+        finally:
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            loop.close()
+            self._loop = None
+
+    def ensure_running(self) -> asyncio.AbstractEventLoop:
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            return loop
+
+        with self._lock:
+            loop = self._loop
+            if loop is not None and loop.is_running():
+                return loop
+
+            self._loop_ready.clear()
+            self._thread = threading.Thread(
+                target=self._run_loop,
+                name="parserator-run-async",
+                daemon=True,
+            )
+            self._thread.start()
+
+        self._loop_ready.wait()
+        assert self._loop is not None
+        return self._loop
+
+    def stop(self) -> None:
+        with self._lock:
+            loop = self._loop
+            thread = self._thread
+
+        if loop is not None and loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
+
+        if thread is not None:
+            thread.join(timeout=1.0)
+
+        with self._lock:
+            self._loop = None
+            self._thread = None
+
+    def run(self, coroutine: Awaitable[_T]) -> _T:
+        loop = self.ensure_running()
+        future = asyncio.run_coroutine_threadsafe(coroutine, loop)
+        return future.result()
+
+
+_BACKGROUND_LOOP = _BackgroundLoop()
+atexit.register(_BACKGROUND_LOOP.stop)
+
+
+def run_async(call: Callable[[], Awaitable[_T]] | Awaitable[_T]) -> _T:
+    """Execute an awaitable in synchronous contexts.
+
+    The Parserator integrations need to invoke the async SDK client from
+    synchronous entry points exposed to third-party frameworks. When those
+    frameworks already have an event loop running (for example, in Jupyter
+    notebooks or async agent runtimes), ``asyncio.run`` cannot be used
+    directly. This helper detects that scenario and offloads execution to a
+    dedicated thread where a private event loop can safely drive the coroutine.
+
+    The helper accepts either a callable that returns an awaitable or an
+    awaitable object directly. In both cases, execution happens inside a copy
+    of the current :mod:`contextvars` context so request-scoped data is
+    preserved even when the coroutine is resolved on a different thread.
+    """
+
+    context = contextvars.copy_context()
+
+    def produce() -> Awaitable[_T]:
+        if isinstance(call, Awaitable):
+            awaitable = call
+        elif callable(call):
+            awaitable = call()
+        else:  # pragma: no cover - defensive
+            raise TypeError("run_async expected an awaitable or a callable returning one")
+
+        if not isinstance(awaitable, Awaitable):
+            raise TypeError("run_async received a non-awaitable value")
+
+        return awaitable
+
+    awaitable = context.run(produce)
+
+    def execute() -> _T:
+        def runner() -> _T:
+            coroutine = _resolve(awaitable)
+            return asyncio.run(coroutine)
+
+        return context.run(runner)
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return execute()
+
+    coroutine = context.run(lambda: _resolve(awaitable))
+    return _BACKGROUND_LOOP.run(coroutine)

--- a/active-development/packages/sdk-python/src/parserator/integrations/autogpt.py
+++ b/active-development/packages/sdk-python/src/parserator/integrations/autogpt.py
@@ -1,10 +1,9 @@
-"""
-AutoGPT Integration for Parserator
-Provides plugin for AutoGPT agents to parse unstructured data
-"""
+"""AutoGPT integration helpers built on the async Parserator SDK."""
 
-from typing import Any, Dict, List, Optional, Tuple
+from __future__ import annotations
+
 import json
+from typing import Any, Dict, List, Optional
 
 try:
     from autogpt.agent import Agent
@@ -15,11 +14,12 @@ except ImportError:
     AUTOGPT_AVAILABLE = False
     command = lambda *args, **kwargs: lambda func: func
 
-from ..services import ParseatorClient
-from ..types import ParseResult
+from ..client import ParseratorClient
+from ..types import ParseResponse
+from ._async_utils import run_async
 
 
-class ParseatorPlugin:
+class ParseratorPlugin:
     """
     AutoGPT plugin for parsing unstructured data using Parserator.
     
@@ -28,7 +28,7 @@ class ParseatorPlugin:
     
     Installation:
         1. Place this file in your AutoGPT plugins directory
-        2. Add "ParseatorPlugin" to your enabled plugins list
+        2. Add "ParseratorPlugin" to your enabled plugins list
         3. Set PARSERATOR_API_KEY in your environment variables
         
     Example usage:
@@ -47,7 +47,7 @@ class ParseatorPlugin:
             
         self.config = config
         self.api_key = self._get_api_key()
-        self.client = ParseatorClient(api_key=self.api_key) if self.api_key else None
+        self.client = ParseratorClient(api_key=self.api_key) if self.api_key else None
         
     def _get_api_key(self) -> Optional[str]:
         """Get API key from environment or config."""
@@ -109,25 +109,29 @@ class ParseatorPlugin:
             })
         
         try:
-            result = self.client.parse(
-                input_data=text,
-                output_schema=schema,
-                instructions=instructions
+            response: ParseResponse = run_async(
+                self.client.parse(
+                    input_data=text,
+                    output_schema=schema,
+                    instructions=instructions,
+                )
             )
-            
-            if result.success:
-                return json.dumps({
-                    "success": True,
-                    "parsed_data": result.parsed_data,
-                    "confidence": result.metadata.get("confidence", 0.0),
-                    "processing_time_ms": result.metadata.get("processingTimeMs", 0)
-                }, indent=2)
-            else:
-                return json.dumps({
-                    "success": False,
-                    "error": result.error_message
-                })
-                
+
+            if response.success:
+                return json.dumps(
+                    {
+                        "success": True,
+                        "parsed_data": response.parsed_data,
+                        "confidence": response.metadata.get("confidence", 0.0),
+                        "processing_time_ms": response.metadata.get(
+                            "processingTimeMs", 0
+                        ),
+                    },
+                    indent=2,
+                )
+
+            return json.dumps({"success": False, "error": response.error_message})
+
         except Exception as e:
             return json.dumps({
                 "success": False,
@@ -371,9 +375,9 @@ class ParseatorPlugin:
 
 
 # Plugin registration for AutoGPT
-def register() -> ParseatorPlugin:
+def register() -> ParseratorPlugin:
     """Register the Parserator plugin with AutoGPT."""
-    return ParseatorPlugin()
+    return ParseratorPlugin()
 
 
 # Helper functions for plugin usage

--- a/active-development/packages/sdk-python/src/parserator/integrations/crewai.py
+++ b/active-development/packages/sdk-python/src/parserator/integrations/crewai.py
@@ -1,10 +1,10 @@
-"""
-CrewAI Integration for Parserator
-Provides tools for CrewAI agents to parse unstructured data
-"""
+"""CrewAI integration helpers built on the async Parserator SDK."""
 
-from typing import Any, Dict, List, Optional, Type
-from pydantic import BaseModel, Field
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import Field
 
 try:
     from crewai_tools import BaseTool
@@ -13,11 +13,12 @@ except ImportError:
     CREWAI_AVAILABLE = False
     BaseTool = object
 
-from ..services import ParseatorClient
-from ..types import ParseResult
+from ..client import ParseratorClient
+from ..types import ParseResponse
+from ._async_utils import run_async
 
 
-class ParseatorTool(BaseTool):
+class ParseratorTool(BaseTool):
     """
     CrewAI tool for parsing unstructured data using Parserator.
     
@@ -26,11 +27,11 @@ class ParseatorTool(BaseTool):
     
     Example:
         ```python
-        from parserator.integrations.crewai import ParseatorTool
+        from parserator.integrations.crewai import ParseratorTool
         from crewai import Agent, Task, Crew
         
         # Create Parserator tool
-        parser_tool = ParseatorTool(
+        parser_tool = ParseratorTool(
             api_key="your_api_key",
             name="data_parser",
             description="Parse unstructured data into JSON"
@@ -70,7 +71,7 @@ class ParseatorTool(BaseTool):
         name: str = "parserator",
         description: str = "Parse unstructured text into structured JSON data",
         base_url: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ):
         if not CREWAI_AVAILABLE:
             raise ImportError(
@@ -85,10 +86,7 @@ class ParseatorTool(BaseTool):
             **kwargs
         )
         
-        self.client = ParseatorClient(
-            api_key=api_key,
-            base_url=base_url
-        )
+        self.client = ParseratorClient(api_key=api_key, base_url=base_url)
     
     def _run(
         self,
@@ -108,26 +106,28 @@ class ParseatorTool(BaseTool):
             Structured data according to output_schema
         """
         try:
-            result = self.client.parse(
-                input_data=input_data,
-                output_schema=output_schema,
-                instructions=instructions
+            response: ParseResponse = run_async(
+                self.client.parse(
+                    input_data=input_data,
+                    output_schema=output_schema,
+                    instructions=instructions,
+                )
             )
-            
-            if not result.success:
+
+            if not response.success:
                 return {
                     "error": True,
-                    "message": result.error_message,
-                    "parsed_data": None
+                    "message": response.error_message,
+                    "parsed_data": None,
                 }
-            
+
             return {
                 "error": False,
-                "parsed_data": result.parsed_data,
-                "confidence": result.metadata.get("confidence", 0.0),
-                "processing_time": result.metadata.get("processingTimeMs", 0)
+                "parsed_data": response.parsed_data,
+                "confidence": response.metadata.get("confidence", 0.0),
+                "processing_time": response.metadata.get("processingTimeMs", 0),
             }
-            
+
         except Exception as e:
             return {
                 "error": True,
@@ -136,7 +136,7 @@ class ParseatorTool(BaseTool):
             }
 
 
-class EmailParserTool(ParseatorTool):
+class EmailParserTool(ParseratorTool):
     """Specialized CrewAI tool for parsing email content."""
     
     name: str = "email_parser"
@@ -168,7 +168,7 @@ class EmailParserTool(ParseatorTool):
         )
 
 
-class DocumentParserTool(ParseatorTool):
+class DocumentParserTool(ParseratorTool):
     """Specialized CrewAI tool for parsing document content."""
     
     name: str = "document_parser" 
@@ -213,7 +213,7 @@ class DocumentParserTool(ParseatorTool):
         )
 
 
-class ContactParserTool(ParseatorTool):
+class ContactParserTool(ParseratorTool):
     """Specialized CrewAI tool for parsing contact information."""
     
     name: str = "contact_parser"
@@ -239,7 +239,7 @@ class ContactParserTool(ParseatorTool):
         )
 
 
-class DataExtractionTool(ParseatorTool):
+class DataExtractionTool(ParseratorTool):
     """Flexible CrewAI tool for custom data extraction."""
     
     name: str = "data_extractor"
@@ -296,7 +296,7 @@ def create_parsing_agent(api_key: str, tools: Optional[List[str]] = None) -> Dic
         elif tool_type == 'contact':
             agent_tools.append(ContactParserTool(api_key=api_key))
         elif tool_type == 'general':
-            agent_tools.append(ParseatorTool(api_key=api_key))
+            agent_tools.append(ParseratorTool(api_key=api_key))
         elif tool_type == 'extractor':
             agent_tools.append(DataExtractionTool(api_key=api_key))
     

--- a/active-development/packages/sdk-python/src/parserator/integrations/langchain.py
+++ b/active-development/packages/sdk-python/src/parserator/integrations/langchain.py
@@ -1,10 +1,10 @@
-"""
-LangChain Integration for Parserator
-Provides output parser for LangChain agents and chains
-"""
+"""LangChain integration helpers built on the async Parserator SDK."""
 
-from typing import Any, Dict, List, Optional, Union
-from pydantic import BaseModel, Field
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import Field
 
 try:
     from langchain.schema import BaseOutputParser
@@ -15,11 +15,12 @@ except ImportError:
     BaseOutputParser = object
     OutputParserException = Exception
 
-from ..services import ParseatorClient
-from ..types import ParseResult
+from ..client import ParseratorClient
+from ..types import ParseResponse
+from ._async_utils import run_async
 
 
-class ParseatorOutputParser(BaseOutputParser):
+class ParseratorOutputParser(BaseOutputParser):
     """
     LangChain output parser using Parserator's two-stage parsing engine.
     
@@ -28,7 +29,7 @@ class ParseatorOutputParser(BaseOutputParser):
     
     Example:
         ```python
-        from parserator.integrations.langchain import ParseatorOutputParser
+        from parserator.integrations.langchain import ParseratorOutputParser
         
         # Define your desired output structure
         schema = {
@@ -38,7 +39,7 @@ class ParseatorOutputParser(BaseOutputParser):
             "action_items": "array"
         }
         
-        parser = ParseatorOutputParser(
+        parser = ParseratorOutputParser(
             api_key="your_api_key",
             output_schema=schema
         )
@@ -76,7 +77,7 @@ class ParseatorOutputParser(BaseOutputParser):
         output_schema: Dict[str, Any],
         instructions: Optional[str] = None,
         base_url: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ):
         if not LANGCHAIN_AVAILABLE:
             raise ImportError(
@@ -91,11 +92,8 @@ class ParseatorOutputParser(BaseOutputParser):
             **kwargs
         )
         
-        self.client = ParseatorClient(
-            api_key=api_key,
-            base_url=base_url
-        )
-    
+        self.client = ParseratorClient(api_key=api_key, base_url=base_url)
+
     def parse(self, text: str) -> Dict[str, Any]:
         """
         Parse unstructured text into structured data.
@@ -110,19 +108,21 @@ class ParseatorOutputParser(BaseOutputParser):
             OutputParserException: If parsing fails
         """
         try:
-            result = self.client.parse(
-                input_data=text,
-                output_schema=self.output_schema,
-                instructions=self.instructions
-            )
-            
-            if not result.success:
-                raise OutputParserException(
-                    f"Parserator parsing failed: {result.error_message}"
+            response: ParseResponse = run_async(
+                self.client.parse(
+                    input_data=text,
+                    output_schema=self.output_schema,
+                    instructions=self.instructions,
                 )
-                
-            return result.parsed_data
-            
+            )
+
+            if not response.success:
+                raise OutputParserException(
+                    f"Parserator parsing failed: {response.error_message}"
+                )
+
+            return response.parsed_data
+
         except Exception as e:
             raise OutputParserException(f"Failed to parse with Parserator: {str(e)}")
     
@@ -144,7 +144,7 @@ class ParseatorOutputParser(BaseOutputParser):
         return "parserator"
 
 
-class ParseatorChainOutputParser(ParseatorOutputParser):
+class ParseratorChainOutputParser(ParseratorOutputParser):
     """
     Enhanced output parser for complex LangChain workflows.
     
@@ -160,7 +160,7 @@ class ParseatorChainOutputParser(ParseatorOutputParser):
         output_schema: Dict[str, Any],
         retry_attempts: int = 2,
         fallback_schema: Optional[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             api_key=api_key,
@@ -187,16 +187,18 @@ class ParseatorChainOutputParser(ParseatorOutputParser):
         # Try fallback schema if available
         if self.fallback_schema:
             try:
-                result = self.client.parse(
-                    input_data=text,
-                    output_schema=self.fallback_schema,
-                    instructions=self.instructions
+                response: ParseResponse = run_async(
+                    self.client.parse(
+                        input_data=text,
+                        output_schema=self.fallback_schema,
+                        instructions=self.instructions,
+                    )
                 )
-                
-                if result.success:
-                    return result.parsed_data
-                    
-            except Exception as fallback_error:
+
+                if response.success:
+                    return response.parsed_data
+
+            except Exception:
                 pass
         
         # All attempts failed
@@ -205,7 +207,7 @@ class ParseatorChainOutputParser(ParseatorOutputParser):
         )
 
 
-class ParseatorListOutputParser(ParseatorOutputParser):
+class ParseratorListOutputParser(ParseratorOutputParser):
     """
     Specialized parser for extracting lists and arrays from text.
     
@@ -244,7 +246,7 @@ class ParseatorListOutputParser(ParseatorOutputParser):
 
 
 # Helper functions for common use cases
-def create_email_parser(api_key: str) -> ParseatorOutputParser:
+def create_email_parser(api_key: str) -> ParseratorOutputParser:
     """Create a pre-configured parser for email content."""
     schema = {
         "sender": "string",
@@ -257,14 +259,14 @@ def create_email_parser(api_key: str) -> ParseatorOutputParser:
         "important_dates": "array"
     }
     
-    return ParseatorOutputParser(
+    return ParseratorOutputParser(
         api_key=api_key,
         output_schema=schema,
         instructions="Extract key information from email content"
     )
 
 
-def create_document_parser(api_key: str) -> ParseatorOutputParser:
+def create_document_parser(api_key: str) -> ParseratorOutputParser:
     """Create a pre-configured parser for document analysis."""
     schema = {
         "title": "string",
@@ -276,14 +278,14 @@ def create_document_parser(api_key: str) -> ParseatorOutputParser:
         "next_steps": "array"
     }
     
-    return ParseatorOutputParser(
+    return ParseratorOutputParser(
         api_key=api_key,
         output_schema=schema,
         instructions="Analyze document content and extract structured information"
     )
 
 
-def create_research_parser(api_key: str) -> ParseatorOutputParser:
+def create_research_parser(api_key: str) -> ParseratorOutputParser:
     """Create a pre-configured parser for research content."""
     schema = {
         "findings": "array",
@@ -294,7 +296,7 @@ def create_research_parser(api_key: str) -> ParseatorOutputParser:
         "statistical_data": "array"
     }
     
-    return ParseatorOutputParser(
+    return ParseratorOutputParser(
         api_key=api_key,
         output_schema=schema,
         instructions="Extract research findings and methodology information"

--- a/active-development/packages/sdk-python/tests/integrations/test_async_utils.py
+++ b/active-development/packages/sdk-python/tests/integrations/test_async_utils.py
@@ -1,0 +1,115 @@
+"""Tests for the synchronous bridge used by Parserator integrations."""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import importlib.util
+import threading
+from pathlib import Path
+
+import pytest
+
+module_path = Path(__file__).resolve().parents[2] / "src" / "parserator" / "integrations" / "_async_utils.py"
+spec = importlib.util.spec_from_file_location("parserator.integrations._async_utils", module_path)
+_async_utils = importlib.util.module_from_spec(spec)
+assert spec.loader is not None  # for mypy/static tools
+spec.loader.exec_module(_async_utils)
+run_async = _async_utils.run_async
+
+
+async def _return_value(value: str) -> str:
+    await asyncio.sleep(0)
+    return value
+
+
+def test_run_async_executes_coroutine_without_running_loop():
+    """The helper should run coroutines when no loop is active."""
+
+    result = run_async(lambda: _return_value("ok"))
+    assert result == "ok"
+
+
+def test_run_async_accepts_coroutine_object():
+    """A coroutine object can be supplied directly."""
+
+    result = run_async(_return_value("direct"))
+    assert result == "direct"
+
+
+def test_run_async_handles_running_loop():
+    """When a loop is already running, execution should still succeed."""
+
+    async def runner() -> str:
+        return run_async(lambda: _return_value("loop"))
+
+    assert asyncio.run(runner()) == "loop"
+
+
+def test_run_async_uses_background_thread_for_running_loop():
+    """Coroutines dispatched from a running loop should execute on the helper thread."""
+
+    async def capture_thread() -> str:
+        return threading.current_thread().name
+
+    async def runner() -> tuple[str, str]:
+        first = run_async(capture_thread)
+        second = run_async(capture_thread)
+        return first, second
+
+    thread_one, thread_two = asyncio.run(runner())
+
+    assert thread_one == thread_two == "parserator-run-async"
+
+
+def test_run_async_preserves_contextvars_in_thread():
+    """Context variables should flow through when no loop is running."""
+
+    marker: contextvars.ContextVar[str | None] = contextvars.ContextVar("marker", default=None)
+    token = marker.set("thread-context")
+
+    async def read_marker() -> str | None:
+        return marker.get()
+
+    try:
+        assert run_async(read_marker) == "thread-context"
+    finally:
+        marker.reset(token)
+
+
+def test_run_async_preserves_contextvars_from_running_loop():
+    """Context variables set inside an active loop should propagate."""
+
+    marker: contextvars.ContextVar[str | None] = contextvars.ContextVar("marker", default=None)
+
+    async def runner() -> str | None:
+        token = marker.set("running-loop")
+        try:
+            async def read_marker() -> str | None:
+                return marker.get()
+
+            return run_async(read_marker)
+        finally:
+            marker.reset(token)
+
+    assert asyncio.run(runner()) == "running-loop"
+
+
+def test_run_async_propagates_exceptions():
+    """Errors raised by the awaitable should bubble up."""
+
+    async def raises() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        run_async(raises)
+
+
+def test_run_async_rejects_nonawaitable():
+    """Passing a callable that does not yield an awaitable should fail."""
+
+    def not_async():
+        return "not awaitable"
+
+    with pytest.raises(TypeError):
+        run_async(not_async)

--- a/active-development/packages/sdk-python/tests/integrations/test_parserator_integrations.py
+++ b/active-development/packages/sdk-python/tests/integrations/test_parserator_integrations.py
@@ -1,0 +1,353 @@
+"""Unit tests for Parserator framework integrations.
+
+These tests provide lightweight stubs for optional third-party dependencies
+and ensure the integration helpers synchronously execute the async SDK client.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def add_sdk_src_to_path():
+    """Ensure the Parserator package under src/ is importable during tests."""
+
+    sdk_src = Path(__file__).resolve().parents[2] / "src"
+    sys.path.insert(0, str(sdk_src))
+
+    try:
+        yield
+    finally:
+        if str(sdk_src) in sys.path:
+            sys.path.remove(str(sdk_src))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def stub_third_party_modules():
+    """Provide lightweight stand-ins for optional integration dependencies."""
+
+    created: Dict[str, types.ModuleType] = {}
+
+    # Pydantic placeholder used by multiple integrations
+    pydantic_module = types.ModuleType("pydantic")
+
+    class BaseModel:  # pragma: no cover - minimal stub
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    def Field(*_args: Any, **_kwargs: Any):  # pragma: no cover - stub helper
+        return None
+
+    pydantic_module.BaseModel = BaseModel
+    pydantic_module.Field = Field
+    created["pydantic"] = pydantic_module
+
+    # LangChain schema stubs
+    langchain_module = types.ModuleType("langchain")
+    schema_module = types.ModuleType("langchain.schema")
+
+    class BaseOutputParser:  # pragma: no cover - minimal stub
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    class OutputParserException(Exception):
+        pass
+
+    schema_module.BaseOutputParser = BaseOutputParser
+    output_parser_module = types.ModuleType("langchain.schema.output_parser")
+    output_parser_module.OutputParserException = OutputParserException
+    langchain_module.schema = schema_module
+
+    created["langchain"] = langchain_module
+    created["langchain.schema"] = schema_module
+    created["langchain.schema.output_parser"] = output_parser_module
+
+    # CrewAI tool stub
+    crewai_tools_module = types.ModuleType("crewai_tools")
+
+    class BaseTool:  # pragma: no cover - minimal stub
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    crewai_tools_module.BaseTool = BaseTool
+    created["crewai_tools"] = crewai_tools_module
+
+    # AutoGPT stubs
+    autogpt_module = types.ModuleType("autogpt")
+    agent_module = types.ModuleType("autogpt.agent")
+
+    class Agent:  # pragma: no cover - minimal stub
+        pass
+
+    agent_module.Agent = Agent
+    command_module = types.ModuleType("autogpt.command_decorator")
+
+    def command(*_args: Any, **_kwargs: Any):  # pragma: no cover - minimal stub
+        def decorator(func):
+            return func
+
+        return decorator
+
+    command_module.command = command
+    config_module = types.ModuleType("autogpt.config")
+
+    class Config:  # pragma: no cover - minimal stub
+        parserator_api_key: str | None = None
+
+    config_module.Config = Config
+    autogpt_module.agent = agent_module
+    autogpt_module.command_decorator = command_module
+    autogpt_module.config = config_module
+
+    created.update(
+        {
+            "autogpt": autogpt_module,
+            "autogpt.agent": agent_module,
+            "autogpt.command_decorator": command_module,
+            "autogpt.config": config_module,
+        }
+    )
+
+    previous: Dict[str, types.ModuleType | None] = {
+        name: sys.modules.get(name) for name in created
+    }
+    sys.modules.update(created)
+
+    try:
+        yield
+    finally:
+        for name, module in created.items():
+            if previous[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous[name]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def stub_parserator_sdk_modules():
+    """Provide placeholder Parserator SDK modules expected by integrations."""
+
+    created: Dict[str, types.ModuleType] = {}
+
+    types_module = types.ModuleType("parserator.types")
+
+    class ParseResponse:
+        def __init__(
+            self,
+            success: bool = True,
+            parsed_data: Dict[str, Any] | None = None,
+            metadata: Dict[str, Any] | None = None,
+            error_message: str | None = None,
+        ) -> None:
+            self.success = success
+            self.parsed_data = parsed_data or {}
+            self.metadata = metadata or {}
+            self.error_message = error_message
+
+    # Lightweight placeholders for other exported SDK symbols
+    placeholder_class_names = [
+        "ParseRequest",
+        "ParseOptions",
+        "ParseMetadata",
+        "ParseratorConfig",
+        "BatchParseRequest",
+        "BatchParseResponse",
+        "BatchOptions",
+        "SearchStep",
+        "SearchPlan",
+        "ValidationType",
+        "ParseError",
+        "ErrorCode",
+        "SchemaValidationResult",
+        "ParsePreset",
+    ]
+    for name in placeholder_class_names:
+        setattr(types_module, name, type(name, (), {}))
+
+    types_module.ParseResponse = ParseResponse
+    created["parserator.types"] = types_module
+
+    client_module = types.ModuleType("parserator.client")
+
+    class ParseratorClient:  # pragma: no cover - replaced with AsyncMock per test
+        async def parse(self, **_kwargs: Any) -> ParseResponse:
+            return ParseResponse()
+
+    client_module.ParseratorClient = ParseratorClient
+    created["parserator.client"] = client_module
+
+    errors_module = types.ModuleType("parserator.errors")
+    for name in [
+        "ParseratorError",
+        "ValidationError",
+        "AuthenticationError",
+        "RateLimitError",
+        "QuotaExceededError",
+        "NetworkError",
+        "TimeoutError",
+        "ParseFailedError",
+        "ServiceUnavailableError",
+    ]:
+        errors_module.__dict__[name] = type(name, (Exception,), {})
+    created["parserator.errors"] = errors_module
+
+    presets_module = types.ModuleType("parserator.presets")
+    for name in [
+        "EMAIL_PARSER",
+        "INVOICE_PARSER",
+        "CONTACT_PARSER",
+        "CSV_PARSER",
+        "LOG_PARSER",
+        "DOCUMENT_PARSER",
+        "ALL_PRESETS",
+    ]:
+        setattr(presets_module, name, {})
+
+    def _return_dummy(*_args: Any, **_kwargs: Any):  # pragma: no cover - stub
+        return {}
+
+    presets_module.get_preset_by_name = _return_dummy
+    presets_module.list_available_presets = lambda: []
+    created["parserator.presets"] = presets_module
+
+    utils_module = types.ModuleType("parserator.utils")
+    for name in [
+        "validate_api_key",
+        "validate_schema",
+        "validate_input_data",
+        "to_pandas",
+        "to_polars",
+        "to_numpy",
+        "from_pandas",
+        "from_polars",
+    ]:
+        utils_module.__dict__[name] = lambda *_a, **_k: True
+
+    utils_module.DataFrame = object
+    utils_module.Series = object
+    created["parserator.utils"] = utils_module
+
+    previous: Dict[str, types.ModuleType | None] = {
+        name: sys.modules.get(name) for name in created
+    }
+    sys.modules.update(created)
+
+    try:
+        yield ParseResponse
+    finally:
+        for name in created:
+            if previous[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous[name]
+
+
+@pytest.fixture()
+def parse_response():
+    """Return the stub ParseResponse class for convenience."""
+
+    from parserator.types import ParseResponse
+
+    return ParseResponse
+
+
+def test_langchain_output_parser_sync_executes_async_client(monkeypatch, parse_response):
+    import importlib
+
+    module = importlib.import_module("parserator.integrations.langchain")
+
+    response = parse_response(
+        success=True,
+        parsed_data={"field": "value"},
+        metadata={"confidence": 0.91, "processingTimeMs": 42},
+    )
+
+    async_client = AsyncMock()
+    async_client.parse.return_value = response
+
+    class ClientFactory:
+        def __init__(self) -> None:
+            self.instance = async_client
+
+        def __call__(self, **_kwargs: Any) -> AsyncMock:
+            return async_client
+
+    monkeypatch.setattr(module, "ParseratorClient", ClientFactory())
+
+    parser = module.ParseratorOutputParser(
+        api_key="test", output_schema={"field": "string"}
+    )
+    result = parser.parse("example")
+
+    assert result == {"field": "value"}
+    async_client.parse.assert_awaited()
+
+
+def test_crewai_tool_returns_structured_payload(monkeypatch, parse_response):
+    import importlib
+
+    module = importlib.import_module("parserator.integrations.crewai")
+
+    response = parse_response(
+        success=True,
+        parsed_data={"summary": "ok"},
+        metadata={"confidence": 0.73},
+    )
+
+    async_client = AsyncMock()
+    async_client.parse.return_value = response
+
+    class ClientFactory:
+        def __call__(self, **_kwargs: Any) -> AsyncMock:
+            return async_client
+
+    monkeypatch.setattr(module, "ParseratorClient", ClientFactory())
+    tool = module.ParseratorTool(api_key="key")
+    payload = tool._run("text", {"summary": "string"})
+
+    assert payload["parsed_data"] == {"summary": "ok"}
+    assert payload["error"] is False
+    async_client.parse.assert_awaited()
+
+
+def test_autogpt_plugin_parses_and_formats_json(monkeypatch, parse_response):
+    import importlib
+
+    module = importlib.import_module("parserator.integrations.autogpt")
+    monkeypatch.setattr(module, "AUTOGPT_AVAILABLE", True)
+    monkeypatch.setenv("PARSERATOR_API_KEY", "key")
+
+    response = parse_response(
+        success=True,
+        parsed_data={"name": "Parserator"},
+        metadata={"processingTimeMs": 21},
+    )
+
+    async_client = AsyncMock()
+    async_client.parse.return_value = response
+
+    class ClientFactory:
+        def __call__(self, **_kwargs: Any) -> AsyncMock:
+            return async_client
+
+    monkeypatch.setattr(module, "ParseratorClient", ClientFactory())
+
+    plugin = module.ParseratorPlugin()
+    result_json = plugin.parse_text("text", {"name": "string"})
+    payload = json.loads(result_json)
+
+    assert payload["success"] is True
+    assert payload["parsed_data"] == {"name": "Parserator"}
+    async_client.parse.assert_awaited()
+
+    # The register helper should instantiate without error
+    registered = module.register()
+    assert isinstance(registered, module.ParseratorPlugin)


### PR DESCRIPTION
## Summary
- update the `run_async` helper to reuse a dedicated background loop while preserving context propagation and safe execution when other loops are running
- adjust the AutoGPT, CrewAI, and LangChain integrations to call the shared bridge with real client coroutines
- add dedicated async bridge unit tests that exercise coroutine execution, context propagation, helper thread reuse, and error surfacing

## Testing
- pytest active-development/packages/sdk-python/tests/integrations -q

------
https://chatgpt.com/codex/tasks/task_e_68dc093ad1288329a342326610de56e4